### PR TITLE
add Lokl to Hosting/Deployment

### DIFF
--- a/content/tool/lokl.md
+++ b/content/tool/lokl.md
@@ -1,0 +1,36 @@
+---
+title: Lokl
+repo: 
+weight: ''
+description: Lokl is a simple, optimized local environment for using WordPress as a
+  static site generator.
+date: 2021-06-15 00:00:00 -0400
+tools:
+- Hosting-Deployment
+interactions: []
+license: The Unlicense
+data_model: ''
+language: ''
+related_tools: []
+tags:
+- Docker WordPress shell
+urls:
+  website: https://lokl.dev
+  github: https://github.com/leonstafford/lokl-cli
+  twitter: https://twitter.com/LoklDev
+  other: ''
+resources: []
+
+---
+
+Lokl is a simple, optimized local environment for using WordPress as a
+  static site generator.
+
+Comes bundled with latest builds of WP2Static and Static HTML Output.
+
+Allows you to run 1 or 100's of WP dev sites locally, publishing to S3, Netlify,
+ Vercel and more.
+
+Get started with a single command:
+
+`sh -c "$(curl -sSl 'https://lokl.dev/cli-5.0.0')"`


### PR DESCRIPTION
Lokl is a simple, optimized local environment for using WordPress as a static site generator.